### PR TITLE
Add Essay and Quiz Questions for API Docs Components

### DIFF
--- a/docs/api-docs-course/api-data-format.mdx
+++ b/docs/api-docs-course/api-data-format.mdx
@@ -247,3 +247,45 @@ We did not cover the syntax in this course but we have picked out some of the be
 Here are some of them:
 
 [Binary Data API](https://bun.sh/docs/api/binary-data): This explains the syntax and usage of Binary Data format.
+
+:::tip[Exercise]
+
+
+Explain the trade-offs and considerations when choosing between JSON, YAML, XML, Raw, and Binary formats for an API.
+
+After review, tag @TechnicalWriti6 on Twitter to the link to your article.
+
+:::
+
+
+
+## Answer the following questions
+
+
+import Quiz from '@site/src/components/Quiz';
+
+
+<Quiz
+  questions={[
+    {
+      text: 'In the context of API data formats, “Raw” refers to:',
+      options: [
+        { value: '1', label: 'Unformatted multimedia files only' },
+        { value: '2', label: 'Any data sent unprocessed, including plain text or unencoded JSON or XML' },
+        { value: '3', label: 'A binary-encoded format optimized for speed' },
+        { value: '4', label: 'A markup language alternative to XML' }
+      ],
+      correct: '2'
+    },
+    {
+      text: 'Which format is explained as “JSON without the brackets,” using indentation instead?',
+      options: [
+        { value: '1', label: "XML" },
+        { value: '2', label: 'Raw' },
+        { value: '3', label: 'YAML' },
+        { value: '4', label: 'Protobuf' }
+      ],
+      correct: '3'
+    }
+  ]}
+/>

--- a/docs/api-docs-course/api-data-format.mdx
+++ b/docs/api-docs-course/api-data-format.mdx
@@ -248,15 +248,6 @@ Here are some of them:
 
 [Binary Data API](https://bun.sh/docs/api/binary-data): This explains the syntax and usage of Binary Data format.
 
-:::tip[Exercise]
-
-
-Explain the trade-offs and considerations when choosing between JSON, YAML, XML, Raw, and Binary formats for an API.
-
-After review, tag @TechnicalWriti6 on Twitter to the link to your article.
-
-:::
-
 
 
 ## Answer the following questions
@@ -289,3 +280,15 @@ import Quiz from '@site/src/components/Quiz';
     }
   ]}
 />
+
+&nbsp;
+
+
+:::tip[Exercise]
+
+
+Explain the trade-offs and considerations when choosing between JSON, YAML, XML, Raw, and Binary formats for an API.
+
+After review, tag @TechnicalWriti6 on Twitter to the link to your article.
+
+:::

--- a/docs/api-docs-course/api-specification.mdx
+++ b/docs/api-docs-course/api-specification.mdx
@@ -790,7 +790,7 @@ Preview Documentation on [Apiary](https://apiary.io/)
 
 To learn more about API Blueprint tools, visit [API Blueprint tools.](https://apiblueprint.org/tools.html#)
 
-:::tip[Assignment]
+:::tip[Exercise]
 Use a Swagger editor (like SwaggerHub, Editor.Swagger.io) to create an OpenAPI Specification (OAS) document for the TDMB API.
 The document should include the following elements:
 
@@ -810,3 +810,34 @@ Write a reflection on the experience of documenting the TDMB API using Swagger. 
 
 Lastly, after review, tag @Technicalwrit6 on Twitter and LinkedIn, stating that this is your API Specification assignment.
 :::
+
+
+## Answer the following questions
+
+
+import Quiz from '@site/src/components/Quiz';
+
+<Quiz
+  questions={[
+    {
+      text: 'Which specification language uses Markdown-like syntax (MSON) and typically has a .apib extension?',
+      options: [
+        { value: '1', label: 'OAS' },
+        { value: '2', label: 'JSON Schema' },
+        { value: '3', label: 'API Blueprint' },
+        { value: '4', label: 'RAML' }
+      ],
+      correct: '3'
+    },
+    {
+      text: 'What is the primary purpose of an API specification?',
+      options: [
+        { value: '1', label: "To document user-facing UI interactions" },
+        { value: '2', label: 'To define endpoints, operations, parameters, schemas, and versioning in a standardized format' },
+        { value: '3', label: 'To provide a marketing overview of the API' },
+        { value: '4', label: 'To replace source code entirely' }
+      ],
+      correct: '2'
+    }
+  ]}
+/>

--- a/docs/api-docs-course/api-specification.mdx
+++ b/docs/api-docs-course/api-specification.mdx
@@ -790,27 +790,6 @@ Preview Documentation on [Apiary](https://apiary.io/)
 
 To learn more about API Blueprint tools, visit [API Blueprint tools.](https://apiblueprint.org/tools.html#)
 
-:::tip[Exercise]
-Use a Swagger editor (like SwaggerHub, Editor.Swagger.io) to create an OpenAPI Specification (OAS) document for the TDMB API.
-The document should include the following elements:
-
-- Info: Basic information about the API (title, description, version, contact, license).
-- Paths: Define the API endpoints and their supported HTTP methods (GET, POST, PUT, DELETE).
-- Parameters: Describe query parameters, path parameters, and request bodies for each operation.
-- Responses: Define the expected responses for each operation, including status codes and response schemas.
-- Data Models: Create schemas to represent the data structures used by the API.
-- Security: If authentication is required, specify the security scheme (e.g., API Key, OAuth2) and how it is used.
-
-**Documentation Preview and Generation**: Use Swagger tools to preview the generated API documentation. This will give you an interactive view of the API, similar to what developers will see when using it.
-
-Write a reflection on the experience of documenting the TDMB API using Swagger. Include the following:
-
-- Challenges you faced.
-- Key lessons learned about API documentation and Swagger.
-
-Lastly, after review, tag @Technicalwrit6 on Twitter and LinkedIn, stating that this is your API Specification assignment.
-:::
-
 
 ## Answer the following questions
 
@@ -841,3 +820,26 @@ import Quiz from '@site/src/components/Quiz';
     }
   ]}
 />
+
+&nbsp;
+
+:::tip[Exercise]
+Use a Swagger editor (like SwaggerHub, Editor.Swagger.io) to create an OpenAPI Specification (OAS) document for the TDMB API.
+The document should include the following elements:
+
+- Info: Basic information about the API (title, description, version, contact, license).
+- Paths: Define the API endpoints and their supported HTTP methods (GET, POST, PUT, DELETE).
+- Parameters: Describe query parameters, path parameters, and request bodies for each operation.
+- Responses: Define the expected responses for each operation, including status codes and response schemas.
+- Data Models: Create schemas to represent the data structures used by the API.
+- Security: If authentication is required, specify the security scheme (e.g., API Key, OAuth2) and how it is used.
+
+**Documentation Preview and Generation**: Use Swagger tools to preview the generated API documentation. This will give you an interactive view of the API, similar to what developers will see when using it.
+
+Write a reflection on the experience of documenting the TDMB API using Swagger. Include the following:
+
+- Challenges you faced.
+- Key lessons learned about API documentation and Swagger.
+
+Lastly, after review, tag @Technicalwrit6 on Twitter and LinkedIn, stating that this is your API Specification assignment.
+:::

--- a/docs/api-docs-course/api-tools.mdx
+++ b/docs/api-docs-course/api-tools.mdx
@@ -490,19 +490,6 @@ Here are popular API documentation tools and their unique features.
 | 9.      | Slate              | **Moderate**    | **Moderate**             | **High**          | **Moderate**    | **Markdown**               |
 
 
-:::tip[Exercise]
-
-
-Discuss the key elements of effective API documentation and explain why each element is important. Provide examples of tools that can help create and maintain high-quality API docs.
-
-
-After review, tag @TechnicalWriti6 on Twitter to the link to your article.
-
-
-:::
-
-
-
 
 ## Answer the following questions
 
@@ -534,3 +521,14 @@ import Quiz from '@site/src/components/Quiz';
     }
   ]}
 />
+
+&nbsp;
+
+
+:::tip[Exercise]
+
+Discuss the key elements of effective API documentation and explain why each element is important. Provide examples of tools that can help create and maintain high-quality API docs.
+
+After review, tag @TechnicalWriti6 on Twitter to the link to your article.
+
+:::

--- a/docs/api-docs-course/api-tools.mdx
+++ b/docs/api-docs-course/api-tools.mdx
@@ -488,3 +488,49 @@ Here are popular API documentation tools and their unique features.
 | 7.      | Apiary             | **High**        | **High**                 | **High**          | **High**        | **API Blueprint, Swagger** |
 | 8.      | APIdog             | **High**        | **High**                 | **Moderate**      | **High**        | **Markdown & JSON**        |
 | 9.      | Slate              | **Moderate**    | **Moderate**             | **High**          | **Moderate**    | **Markdown**               |
+
+
+:::tip[Exercise]
+
+
+Discuss the key elements of effective API documentation and explain why each element is important. Provide examples of tools that can help create and maintain high-quality API docs.
+
+
+After review, tag @TechnicalWriti6 on Twitter to the link to your article.
+
+
+:::
+
+
+
+
+## Answer the following questions
+
+
+import Quiz from '@site/src/components/Quiz';
+
+
+<Quiz
+  questions={[
+    {
+      text: 'What is a defining feature of interactive API documentation tools?',
+      options: [
+        { value: '1', label: 'They generate static documentation sites' },
+        { value: '2', label: 'They allow live testing of endpoints (e.g., “Try it out”)' },
+        { value: '3', label: 'They only support Markdown' },
+        { value: '4', label: 'They require downloading the API locally' }
+      ],
+      correct: '2'
+    },
+    {
+      text: 'Which tool is described as non-interactive and focuses on static documentation?',
+      options: [
+        { value: '1', label: "Mintlify" },
+        { value: '2', label: 'Docusaurus' },
+        { value: '3', label: 'Swagger UI' },
+        { value: '4', label: 'Postman' }
+      ],
+      correct: '2'
+    }
+  ]}
+/>

--- a/docs/markup-languages/asciidoc/writing-in-asciidoc.mdx
+++ b/docs/markup-languages/asciidoc/writing-in-asciidoc.mdx
@@ -146,7 +146,7 @@ You're in charge, and you're telling AsciiDoc to:
 
 By using an inline pass macro, you take control of your text's formatting and ensure it looks exactly how you want it to!
 
-![Inline Pass Macro](img\Usingtheinlinepassmacro.png)
+![Inline Pass Macro](img\UsingtheInlinepassmacro.png)
 _**Fig 8:** Using the inline pass macro to prevent AsciiDoc from altering specific
 content._
 {""}

--- a/src/components/blogComponent/BlogSection.jsx
+++ b/src/components/blogComponent/BlogSection.jsx
@@ -1,4 +1,4 @@
-import semrush from './Image/semrush.png';
+import semrush from './image/semrush.png';
 import hugoMigration from "/img/hugo-to-docusaurus.png";
 import JavascriptVariables from './Image/JavascriptVariables.png';
 import styles from './styles.module.css';


### PR DESCRIPTION
This pull request adds educational content in the form of essay and multiple-choice quiz questions to enhance the documentation’s interactivity and learning support.

**Key Updates**:

Created essay and quiz questions for the following sections:

- API Data Format

- API Documentation Tools

- API Specification

**Purpose**:

These additions aim to:

- Help readers test their understanding of key API documentation concepts.
 
- Make the documentation more engaging and beginner-friendly.
 
- Support technical writing mentorship tasks and knowledge reinforcement.

**Notes**:

- The questions are aligned with the content in each respective section.

- Designed with clarity and relevance for learners at all levels.

