### PR TITLE
Feat: Add Docsearch 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,8 +117,22 @@ const config = {
             position: "left",
             label: "Academy",
           },
+      { 
+        label: "Cohort", 
+        position: "left",
+        items: [
+          {
+            label: "API",
+            to: "/cohort/api", // URL path to page one
+          },
 
-          { to: "/blog", label: "Blog", position: "left" },
+          {
+            label: "Product",
+            to: "/cohort/product", // URL path to page one
+          },
+        ],
+      },
+        { to: "/blog", label: "Blog", position: "left" },
           { to: "/write-for-us", label: "Write for us", position: "left" },
 
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,21 +117,21 @@ const config = {
             position: "left",
             label: "Academy",
           },
-      { 
-        label: "Cohort", 
-        position: "left",
-        items: [
-          {
-            label: "API",
-            to: "/cohort/api", // URL path to page one
-          },
+      // { 
+      //   label: "Cohort", 
+      //   position: "left",
+      //   items: [
+      //     {
+      //       label: "API",
+      //       to: "/cohort/api", // URL path to page one
+      //     },
 
-          {
-            label: "Product",
-            to: "/cohort/product", // URL path to page one
-          },
-        ],
-      },
+      //     {
+      //       label: "Product",
+      //       to: "/cohort/product", // URL path to page one
+      //     },
+      //   ],
+      // },
         { to: "/blog", label: "Blog", position: "left" },
           { to: "/write-for-us", label: "Write for us", position: "left" },
 
@@ -208,6 +208,14 @@ const config = {
         ],
         copyright: `Copyright © ${new Date().getFullYear()} Technical Writing Mentorship Program`,
       },
+
+algolia: {
+  appId: '6XU5JO5BGK',
+  apiKey: '597fc683aca1fea4d88169c42926d462',
+  indexName: 'technicalwritingmp',
+  contextualSearch: true,
+},
+
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+# Algolia-Crawler-Verif: 703AFBAFA8DC085D


### PR DESCRIPTION
## What was Fixed

This PR adds doc search by Algolia to the documentation.

## Testing
- Search bar displays well in the nav bar
- Search feature works well when tested locally

## Note
-  I need to verify that the TWMP organization owns the crawled data on the Algolia dashboard once the search feature is deployed live