### PR TITLE
Updated link to the Open SUSE Style guide

### DIFF
--- a/docs/technical-writing-course/Writing-style-guide.mdx
+++ b/docs/technical-writing-course/Writing-style-guide.mdx
@@ -375,7 +375,7 @@ Guides governing technical content in open source projects are crucial for maint
 
 
 - [Gnome Documentation Style Guide](https://developer.gnome.org/documentation/guidelines/devel-docs.html)
-- [Open SUSE Documentation Style Guide](https://documentation.suse.com/style/current/single-html/docu_styleguide/)
+- [Open SUSE Documentation Style Guide](https://documentation.suse.com/style/current/single-html/style-guide-db/style-guide-db.html)
 
 
 ### 5. Government and Academic style guides


### PR DESCRIPTION
Fixed the broken link for the Open SUSE Documentation Style Guide

Previous link: https://documentation.suse.com/inet/documentation/docroot/style/current/

Updated link: https://documentation.suse.com/style/current/single-html/style-guide-db/style-guide-db.html